### PR TITLE
Lead: Ajustado mensagem de erro para Lead já registrado

### DIFF
--- a/lang/en/Leads.php
+++ b/lang/en/Leads.php
@@ -4,7 +4,8 @@ return [
     'success' => 'Your interest in the product has been successfully registered, ' .
         'our team will contact you shortly for more details, you are now on our waiting' .
         'list, as soon as the product is launched you will be notified.',
-    'email.unique' => 'The email provided is already registered in our database.',
+    'email.unique' => 'The email provided is already registered in our database. ' .
+        'Our team will contact you shortly for more details.',
     'email.required' => 'The email field is required.',
     'name.required' => 'The name field is required.',
     'experience_level.required' => 'The experience level field is required.',

--- a/lang/pt-br/Leads.php
+++ b/lang/pt-br/Leads.php
@@ -4,7 +4,8 @@ return [
     'success' => 'Seu interesse  no produto  foi registrado com sucesso, nossa ' .
         'equipe entrará em contato em breve para mais detalhes, você agora esta em ' .
         'nossa fila de espera, assim que o produto for lançado você será notificado.',
-    'email.unique' => 'O email informado já está cadastrado em nossa base de dados.',
+    'email.unique' => 'O email informado já está cadastrado em nossa base de dados. ' .
+        'Logo nossa equipe entrará em contato com você para mais detalhes.',
     'email.required' => 'O campo email é obrigatório.',
     'name.required' => 'O campo nome é obrigatório.',
     'experience_level.required' => 'O campo nível de experiência é obrigatório.',


### PR DESCRIPTION
### O que?

Ajuste mensagem lead

### Por quê?

A mensagem parecia estar incompleta, faltava descrever que ele já está em processo

### Capturas de tela

![image](https://github.com/Zoren-Software/LandingPage-BackEnd-VoleiClub/assets/25940408/d24657d8-dc82-4362-8b1f-66379b574dc0)

