### PR TITLE
Lead: Adicionado notificação no canal do Discord para cada novo Lead

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,6 +2,8 @@
 
 namespace App\Exceptions;
 
+use App\Services\DiscordService;
+use GuzzleHttp\Client as GuzzleClient;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Throwable;
 
@@ -24,7 +26,11 @@ class Handler extends ExceptionHandler
     public function register(): void
     {
         $this->reportable(function (Throwable $e) {
-            //
+            if ($this->shouldReport($e)) {
+                $clientDiscord = new GuzzleClient();
+                $discord = new DiscordService($clientDiscord);
+                $discord->sendError($e, 'Laravel Handler');
+            }
         });
     }
 }

--- a/app/Observers/LeadObserver.php
+++ b/app/Observers/LeadObserver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Lead;
+use App\Services\DiscordService;
+use GuzzleHttp\Client as GuzzleClient;
+
+class LeadObserver
+{
+    public function created(Lead $lead)
+    {
+        // usar discordService para enviar mensagem
+        $clientDiscord = new GuzzleClient();
+
+        $discord = new DiscordService($clientDiscord);
+        $discord->sendNewLead($lead);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -6,6 +6,8 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Event;
+use App\Models\Lead;
+use App\Observers\LeadObserver;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -25,7 +27,7 @@ class EventServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Lead::observe(LeadObserver::class);
     }
 
     /**

--- a/app/Services/DiscordService.php
+++ b/app/Services/DiscordService.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Services;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\ClientException;
+use Illuminate\Database\Eloquent\Model;
+use App\Models\Lead;
+
+final class DiscordService extends Model
+{
+    private $webhookErrors;
+
+    private $webhookNewLead;
+
+    private $client;
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function __construct(GuzzleClient $client)
+    {
+        $this->client = $client;
+
+        $this->webhookErrors = config('services.discord.webhook_errors');
+        $this->webhookNewLead = config('services.discord.webhook_new_leads');
+
+        if (!$this->webhookErrors || !$this->webhookNewLead) {
+            throw new \Throwable('Variáveis de conexão do Discord não declaradas');
+        }
+    }
+
+    /**
+     * @param  Throwable  $exception
+     * @param  string  $message
+     *
+     * @codeCoverageIgnore
+     */
+    public function sendError(\Throwable $error, string $author): void
+    {
+        try {
+            $data = [
+                'content' => null,
+                'embeds' => [
+                    [
+                        'title' => ':warning: ' . $error->getMessage() . ' :warning:',
+                        'description' => $error->getMessage(),
+                        'url' => url()->current(),
+                        'color' => 16711680,
+                        'fields' => [
+                            [
+                                'name' => 'ERROR Resume:',
+                                'value' => 'File: ' . $error->getFile() . " \n In line: " . $error->getLine(),
+                            ],
+                            [
+                                'name' => 'ERROR Code:',
+                                'value' => $error->getCode(),
+                            ],
+                            [
+                                'name' => 'APP_ENV:',
+                                'value' => config('app.env'),
+                            ],
+                            [
+                                'name' => 'APP_DEBUG:',
+                                'value' => config('app.debug'),
+                            ]
+                        ],
+                        'author' => [
+                            'name' => 'ERROR ' . $author,
+                            'icon_url' => 'https://cdn.icon-icons.com/icons2/1808/PNG/64/bug_115148.png',
+                        ],
+                        'timestamp' => date('Y-m-d H:i:s'),
+                    ],
+                ],
+            ];
+
+            if (auth()->user()) {
+                $data['embeds'][0]['fields'][] = [
+                    'name' => 'User ID:',
+                    'value' => auth()->user()->id,
+                ];
+            }
+
+            $this->client->post(
+                $this->webhookErrors,
+                [
+                    'json' => $data,
+                ]
+            );
+        } catch (ClientException $e) {
+            throw new \Throwable('Erro ao enviar mensagem para o Discord');
+        }
+    }
+
+    /**
+     * @param  Throwable  $exception
+     * @param  string  $message
+     *
+     * @codeCoverageIgnore
+     */
+    public function sendNewLead(Lead $lead): void
+    {
+        try {
+            $data = [
+                'content' => null,
+                'embeds' => [
+                    [
+                        'title' => 'New Lead registered in the system Landing Page',
+                        'description' => 'Data New Lead:',
+                        'url' => url()->current(),
+                        'color' => 65280,
+                        'fields' => [
+                            [
+                                'name' => 'Name:',
+                                'value' => $lead->name,
+                            ],
+                            [
+                                'name' => 'E-mail:',
+                                'value' => $lead->email,
+                            ],
+                            [
+                                'name' => 'Experience Level:',
+                                'value' => $lead->experience_level,
+                            ],
+                            [
+                                'name' => 'Message:',
+                                'value' => $lead->message,
+                            ],
+                            [
+                                'name' => 'APP_ENV:',
+                                'value' => config('app.env'),
+                            ],
+                            [
+                                'name' => 'APP_DEBUG:',
+                                'value' => config('app.debug'),
+                            ]
+                        ],
+                        'author' => [
+                            'name' => 'Landing Page',
+                            'icon_url' => 'https://cdn-icons-png.flaticon.com/128/4315/4315445.png',
+                        ],
+                        'timestamp' => date('Y-m-d H:i:s'),
+                    ],
+                ],
+            ];
+
+            if (auth()->user()) {
+                $data['embeds'][0]['fields'][] = [
+                    'name' => 'User ID:',
+                    'value' => auth()->user()->id,
+                ];
+            }
+
+            $this->client->post(
+                $this->webhookNewLead,
+                [
+                    'json' => $data,
+                ]
+            );
+        } catch (ClientException $e) {
+            throw new \Throwable('Erro ao enviar mensagem para o Discord');
+        }
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -31,6 +31,11 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    'discord' => [
+        'webhook_errors' => env('DISCORD_ALERT_ERRORS_WEBHOOK'),
+        'webhook_new_leads' => env('DISCORD_ALERT_NEW_LEADS_WEBHOOK'),
+    ],
+
     'github' => [
         'client_id' => env('GITHUB_CLIENT_ID'),
         'client_secret' => env('GITHUB_CLIENT_SECRET'),


### PR DESCRIPTION
### O que?

Adicionado notificação no canal do discord para cada novo lead registrado no sistema.

### Por quê?

Para notificar os novos registros de interesse em nosso produto.

### Como?

Feito Service para acomodar a API do discord e fazer a notificação da mensagem de registro do Lead, também foi adicionado um canal de notificações de erro da aplicação.

### Capturas de tela

![image](https://github.com/Zoren-Software/LandingPage-BackEnd-VoleiClub/assets/25940408/bbe10304-1eef-4be2-bbea-abbe2152d7e6)
