### PR TITLE
E-mail: Tentativa de resolução de erro ao enviar email via ses

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -48,6 +48,7 @@ return [
 
         'ses' => [
             'transport' => 'ses',
+            'ping_threshold' => 10,
         ],
 
         'mailgun' => [


### PR DESCRIPTION
### O que?

Tentativa de resolução do erro ao enviar e-mail.

### Por quê?

Em alguns momentos específicos é enviado a seguinte mensagem de erro para o canal do discord:
![image](https://github.com/Zoren-Software/LandingPage-BackEnd-VoleiClub/assets/25940408/868eda98-0669-4fd5-a6a8-06ab9c58aa6b)

### Verificações
- [x] Lembrete: Ajustar o `composer.json` com a versão.

