### PR TITLE
fix(vapor): removido comando desnecessário para este ambiente no Laravel Vapor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "The skeleton application for the Laravel framework.",
     "keywords": ["laravel", "framework"],
     "license": "MIT",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.2",

--- a/vapor.yml
+++ b/vapor.yml
@@ -16,7 +16,6 @@ environments:
             - 'php artisan db:seed --force'
             - 'php artisan config:cache'
             - 'php artisan config:clear'
-            - 'php artisan cache:clear'
             - 'php artisan route:clear'
             - 'php artisan view:clear'
             - 'php artisan optimize'


### PR DESCRIPTION
### O que?

Ocorria um problema ao fazer deploy:

```json
ID
38246687896633077924923048959070966953771701491436617732
Log Stream Name
2024/05/07/[31]0cb6283a189944f5bbfeff5fb10ff8cd
Request ID
f097999f-ed90-4429-8abc-02ce109ba8be
Type
ERROR
Location
vendor/laravel/framework/src/Illuminate/Cache/DynamoDbStore.php:459
Message
DynamoDb does not support flushing an entire table. Please create a new table.
{
"exception": {
"class": "RuntimeException",
"message": "DynamoDb does not support flushing an entire table. Please create a new table.",
"code": 0,
"file": "/var/task/vendor/laravel/framework/src/Illuminate/Cache/DynamoDbStore.php:459"
}
}
```

### Por quê?

O ambiente não suporta esse comando de cache, pois ele é um serverless.

### Como?

Removido comando.

### Verificações

- [x] Lembrete: Ajustar o `composer.json` com a versão.

