### PR TITLE
fix(migration): adicionando campo type e softdelete para personal_access_tokens

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "The skeleton application for the Laravel framework.",
     "keywords": ["laravel", "framework"],
     "license": "MIT",
-    "version": "1.8.3",
+    "version": "1.8.4",
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.2",

--- a/database/migrations/2024_05_06_22110000_alter_personal_access_tokens_table.php
+++ b/database/migrations/2024_05_06_22110000_alter_personal_access_tokens_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('personal_access_tokens', 'type')) {
+            Schema::table('personal_access_tokens', function (Blueprint $table) {
+                $table->enum('type', ['web', 'mobile'])->after('name');
+                $table->softDeletes();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('personal_access_tokens', 'type')) {
+            Schema::table('personal_access_tokens', function (Blueprint $table) {
+                $table->dropColumn([
+                    'type',
+                ]);
+                $table->dropSoftDeletes();
+            });
+        }
+    }
+};

--- a/vapor.yml
+++ b/vapor.yml
@@ -10,11 +10,13 @@ environments:
         build:
             - 'composer install --no-dev'
             - 'php artisan event:cache'
+            - 'php artisan optimize'
+            - 'php artisan config:clear'
+            - 'php artisan route:clear'
+            - 'php artisan view:clear'
+            - 'php artisan cache:clear'
           # - 'npm ci && npm run build && rm -rf node_modules'
         deploy:
             - 'php artisan migrate --force'
             - 'php artisan db:seed --force'
             - 'php artisan config:cache'
-            - 'php artisan config:clear'
-            - 'php artisan route:clear'
-            - 'php artisan view:clear'


### PR DESCRIPTION
### O que?

Adicionado migration para adicionar campo faltante em produção.

### Por quê?

Campos não existiam em produção.

### Como?

Criado migration que faz a verificação e adiciona os campos faltantes.

### Verificações
- [x] Lembrete: Ajustar o `composer.json` com a versão.

