### PR TITLE
feat(lead): implementando novos status - LPV-27

### DIFF
--- a/app/Http/Requests/AlterStatusLeadRequest.php
+++ b/app/Http/Requests/AlterStatusLeadRequest.php
@@ -40,6 +40,9 @@ class AlterStatusLeadRequest extends FormRequest implements ScribeInterface
                     'qualified',
                     'bad_email',
                     'spam',
+                    'test',
+                    'trial_period',
+                    'active_customer',
                 ]),
             ],
             'tenantId' => [

--- a/database/migrations/2024_06_02_22110000_alter_leads_table.php
+++ b/database/migrations/2024_06_02_22110000_alter_leads_table.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('leads', 'type')) {
+            Schema::table('leads', function (Blueprint $table) {
+                $table->enum('status', 
+                    [
+                        'new',
+                        'contacted',
+                        'converted',
+                        'unqualified',
+                        'qualified',
+                        'bad_email',
+                        'spam',
+                        'test',
+                        'trial period',
+                    ]
+                )
+                ->default('new')
+                ->change();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('leads', 'type')) {
+            Schema::table('leads', function (Blueprint $table) {
+                $table->enum('status', 
+                    [
+                        'new',
+                        'contacted',
+                        'converted',
+                        'unqualified',
+                        'qualified',
+                        'bad_email',
+                        'spam',
+                    ]
+                )
+                ->default('new')
+                ->change();
+            });
+        }
+    }
+};

--- a/database/migrations/2024_06_02_22110000_alter_leads_table.php
+++ b/database/migrations/2024_06_02_22110000_alter_leads_table.php
@@ -23,7 +23,8 @@ return new class() extends Migration
                         'bad_email',
                         'spam',
                         'test',
-                        'trial period',
+                        'trial_period',
+                        'active_customer',
                     ]
                 )
                 ->default('new')

--- a/tests/Feature/AlterStatusLeadTest.php
+++ b/tests/Feature/AlterStatusLeadTest.php
@@ -79,7 +79,7 @@ class AlterStatusLeadTest extends TestCase
         $faker = \Faker\Factory::create();
 
         return [
-            'alter status lead, alter status new, error' => [
+            'alter status lead, alter status new, success' => [
                 'data' => [
                     'id' => true,
                     'message' => $faker->text(),
@@ -91,7 +91,7 @@ class AlterStatusLeadTest extends TestCase
                 'errorType' => false,
                 'errorExpected' => false,
             ],
-            'alter status lead, alter status contacted, error' => [
+            'alter status lead, alter status contacted, success' => [
                 'data' => [
                     'id' => true,
                     'message' => $faker->text(),
@@ -103,7 +103,7 @@ class AlterStatusLeadTest extends TestCase
                 'errorType' => false,
                 'errorExpected' => false,
             ],
-            'alter status lead, alter status converted, error' => [
+            'alter status lead, alter status converted, success' => [
                 'data' => [
                     'id' => true,
                     'message' => $faker->text(),
@@ -115,7 +115,7 @@ class AlterStatusLeadTest extends TestCase
                 'errorType' => false,
                 'errorExpected' => false,
             ],
-            'alter status lead, alter status unqualified, error' => [
+            'alter status lead, alter status unqualified, success' => [
                 'data' => [
                     'id' => true,
                     'message' => $faker->text(),
@@ -127,7 +127,7 @@ class AlterStatusLeadTest extends TestCase
                 'errorType' => false,
                 'errorExpected' => false,
             ],
-            'alter status lead, alter status qualified, error' => [
+            'alter status lead, alter status qualified, success' => [
                 'data' => [
                     'id' => true,
                     'message' => $faker->text(),
@@ -139,7 +139,7 @@ class AlterStatusLeadTest extends TestCase
                 'errorType' => false,
                 'errorExpected' => false,
             ],
-            'alter status lead, alter status bad_email, error' => [
+            'alter status lead, alter status bad_email, success' => [
                 'data' => [
                     'id' => true,
                     'message' => $faker->text(),
@@ -151,11 +151,47 @@ class AlterStatusLeadTest extends TestCase
                 'errorType' => false,
                 'errorExpected' => false,
             ],
-            'alter status lead, alter status spam, error' => [
+            'alter status lead, alter status spam, success' => [
                 'data' => [
                     'id' => true,
                     'message' => $faker->text(),
                     'status' => 'spam',
+                    'tenantId' => $faker->word(),
+                ],
+                'statusCodeExpected' => 200,
+                'messageExpected' => 'Leads.success_edit_status',
+                'errorType' => false,
+                'errorExpected' => false,
+            ],
+            'alter status lead, alter status test, success' => [
+                'data' => [
+                    'id' => true,
+                    'message' => $faker->text(),
+                    'status' => 'test',
+                    'tenantId' => $faker->word(),
+                ],
+                'statusCodeExpected' => 200,
+                'messageExpected' => 'Leads.success_edit_status',
+                'errorType' => false,
+                'errorExpected' => false,
+            ],
+            'alter status lead, alter status trial period, success' => [
+                'data' => [
+                    'id' => true,
+                    'message' => $faker->text(),
+                    'status' => 'trial_period',
+                    'tenantId' => $faker->word(),
+                ],
+                'statusCodeExpected' => 200,
+                'messageExpected' => 'Leads.success_edit_status',
+                'errorType' => false,
+                'errorExpected' => false,
+            ],
+            'alter status lead, alter status active customer, success' => [
+                'data' => [
+                    'id' => true,
+                    'message' => $faker->text(),
+                    'status' => 'active_customer',
                     'tenantId' => $faker->word(),
                 ],
                 'statusCodeExpected' => 200,


### PR DESCRIPTION
### O que?

Adicionado novas opções para status de leads.

### Por quê?

Era necessário e ficou faltando para o fluxo de leads vindos na landing page.

### Como?

Adicionado na migration as novas opções de status de leads.

### Capturas de tela

![image](https://github.com/Zoren-Software/LandingPage-BackEnd-VoleiClub/assets/25940408/2a5b1787-d28c-457f-a594-3d8a75e8b331)
