### PR TITLE
fix(rotas): correção rotas API que ficaram com o mesmo name - VT-15

### DIFF
--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -45,7 +45,6 @@ class Lead extends Model
 
     private function createInteraction($request)
     {
-        // TODO - Parei na revisão por aqui
         $this->interactions()->create([
             'status_id' => $request->input('status_id') ?? $this->status_id,
             'user_id' => auth()->id(),

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -31,6 +31,8 @@ class EventServiceProvider extends ServiceProvider
     }
 
     /**
+     * @codeCoverageIgnore
+     * 
      * Determine if events and listeners should be automatically discovered.
      */
     public function shouldDiscoverEvents(): bool

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "The skeleton application for the Laravel framework.",
     "keywords": ["laravel", "framework"],
     "license": "MIT",
-    "version": "1.13.0",
+    "version": "1.13.1",
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.2",

--- a/routes/api.php
+++ b/routes/api.php
@@ -70,7 +70,7 @@ Route::group(['prefix' => 'leads'], function () {
         '/unsubscribe/{id}',
         [LeadController::class, 'confirmUnsubscribeEmail']
     )
-        ->name('leads.unsubscribe-email')
+        ->name('leads.confirm-unsubscribe-email')
         ->middleware(['signed', 'throttle:6,1']);
 }
 );

--- a/tests/Feature/ConfirmEmailLeadTest.php
+++ b/tests/Feature/ConfirmEmailLeadTest.php
@@ -71,7 +71,7 @@ class ConfirmEmailLeadTest extends TestCase
         $locale = app()->getLocale();
 
         $url = URL::temporarySignedRoute(
-            'leads.unsubscribe-email',
+            'leads.confirm-email',
             now()->subMinutes(30),
             [
                 'id' => $lead->id,

--- a/tests/Feature/UnsubscribedLeadTest.php
+++ b/tests/Feature/UnsubscribedLeadTest.php
@@ -145,7 +145,7 @@ class UnsubscribedLeadTest extends TestCase
         $locale = app()->getLocale();
 
         $url = URL::temporarySignedRoute(
-            'leads.unsubscribe-email',
+            'leads.confirm-unsubscribe-email',
             now()->addMinutes(30),
             [
                 'id' => $lead->id,
@@ -191,7 +191,7 @@ class UnsubscribedLeadTest extends TestCase
         $locale = app()->getLocale();
 
         $url = URL::temporarySignedRoute(
-            'leads.unsubscribe-email',
+            'leads.confirm-unsubscribe-email',
             now()->subMinutes(30),
             [
                 'id' => $lead->id,


### PR DESCRIPTION
### O que?

Problema nas rotas no momento do deploy

### Por quê?

Rotas em duplicidade com mesmo name

### Como?

Feito a alteração da nomenclatura da rota.

### Verificações
- [x] Lembrete: Ajustar o `composer.json` com a versão.

